### PR TITLE
Update chromedriver version to fix chrome settings tab issue

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "webdriverVersions": {
     "selenium": "2.47.1",
-    "chromedriver": "2.24",
+    "chromedriver": "2.33",
     "iedriver": "2.47.0"
   }
 }


### PR DESCRIPTION
@NarrativeScience/qa @msmathers 
This updates the default version of chromedriver that gets installed for local grunt environments. This is to fix an issue where the chrome setting tab was getting opened while running selenium tests locally.
I verified that this behavior is not happening in jenkins, so I think it makes sense to leave the chromedriver version unchanged there, but let me know if that doesn't seem reasonable.